### PR TITLE
Increase configurability of concurrency and wait duration.

### DIFF
--- a/.i18n-migrations.default.yml
+++ b/.i18n-migrations.default.yml
@@ -4,6 +4,15 @@ migration_dir: i18n/migrate
 # this is where your locale files will live (en.yml, es.yml, etc). it will be relative to your config file
 locales_dir: config/locales
 
+# number of threads to concurrently perform migration operations for locales (optional)
+# concurrency: 4
+
+# number of threads to concurrently perform push operation for locales (optional)
+# push_concurrency: 4
+
+# seconds to wait time between push operations per thread, can be used to avoid API throttling (optional)
+# wait_seconds: 0
+
 # this is the locale you will be translating from
 main_locale: en
 

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@ begin
   require 'rspec/core/rake_task'
   RSpec::Core::RakeTask.new(:spec)
 rescue LoadError
+  # ignore - like in prod
 end
 
 task :default => :spec

--- a/lib/i18n/migrations/config.rb
+++ b/lib/i18n/migrations/config.rb
@@ -4,6 +4,8 @@ module I18n
   module Migrations
     class Config
       CONFIG_FILE_NAME = '.i18n-migrations.yml'
+      DEFAULT_CONCURRENCY = 4
+      DEFAULT_WAIT_SECONDS = 0
 
       def initialize(config_file_name = CONFIG_FILE_NAME)
         @config_file_name = config_file_name
@@ -43,6 +45,18 @@ module I18n
         get_value(:google_translate_api_key)
       end
 
+      def concurrency
+        get_value(:concurrency, DEFAULT_CONCURRENCY)
+      end
+
+      def push_concurrency
+        get_value(:push_concurrency, concurrency)
+      end
+
+      def wait_seconds
+        get_value(:wait_seconds, DEFAULT_WAIT_SECONDS)
+      end
+
       def read!
         yaml_file = find_config_file(@config_file_name)
         unless yaml_file
@@ -72,7 +86,7 @@ module I18n
 
       private
 
-      def get_value(key)
+      def get_value(key, default = nil)
         if key.is_a?(Array)
           value = @config
           key.each do |key_part|
@@ -85,6 +99,8 @@ module I18n
           value
         elsif @config.has_key?(key.to_s)
           @config[key.to_s]
+        elsif default.present?
+          default
         else
           raise ArgumentError, "You must have defined #{key} in #{@root_dir}/#{@config_file_name}"
         end

--- a/lib/i18n/migrations/google_translate_dictionary.rb
+++ b/lib/i18n/migrations/google_translate_dictionary.rb
@@ -143,7 +143,7 @@ module I18n
         url = 'https://www.googleapis.com/language/translate/v2'
         begin
           Faraday.get(url) do |req|
-            req.headers[:accept] = :json
+            req.headers['Content-Type'] = 'application/json'
             req.params = params
           end
         rescue Exception

--- a/lib/i18n/migrations/version.rb
+++ b/lib/i18n/migrations/version.rb
@@ -1,5 +1,5 @@
 module I18n
   module Migrations
-    VERSION = "1.1.4"
+    VERSION = "1.1.5"
   end
 end


### PR DESCRIPTION
Adds `concurrency`, `push_concurrency`, and `wait_seconds` as config parameters that can adjust behavior of the migrator.