### PR TITLE
Release 2.0.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    i18n-migrations (2.0.9)
+    i18n-migrations (2.0.10)
       activesupport
       colorize
       faraday

--- a/lib/i18n/migrations/version.rb
+++ b/lib/i18n/migrations/version.rb
@@ -1,5 +1,5 @@
 module I18n
   module Migrations
-    VERSION = "2.0.9"
+    VERSION = "2.0.10"
   end
 end


### PR DESCRIPTION
New version to release relaxed Ruby version restrictions, updated in https://github.com/transparentclassroom/i18n-migrations/pull/10