### PR TITLE
Make i18n-migrations compatible with Active Support 7.1; bump gem version to 2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.3)
+    activesupport (7.1.3.3)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -23,16 +23,15 @@ GEM
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     base64 (0.2.0)
-    bigdecimal (3.1.6)
+    bigdecimal (3.1.8)
     colorize (0.8.1)
     concurrent-ruby (1.2.3)
-    connection_pool (2.3.0)
+    connection_pool (2.4.1)
     declarative (0.0.20)
     diff-lcs (1.5.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    drb (2.2.0)
-      ruby2_keywords
+    drb (2.2.1)
     faraday (0.17.6)
       multipart-post (>= 1.2, < 3)
     google-apis-core (0.10.0)
@@ -63,7 +62,7 @@ GEM
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    i18n (1.14.1)
+    i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     jwt (2.7.0)
     mail (2.7.1)
@@ -86,7 +85,7 @@ GEM
     mime-types-data (3.2022.0105)
     mini_mime (1.1.2)
     mini_portile2 (2.8.5)
-    minitest (5.18.0)
+    minitest (5.23.1)
     multi_json (1.15.0)
     multipart-post (2.2.3)
     mutex_m (0.2.0)
@@ -127,7 +126,6 @@ GEM
       mail (>= 2.2.1)
       mime (>= 0.1)
       shared-mime-info
-    ruby2_keywords (0.0.5)
     rubyntlm (0.6.3)
     shared-mime-info (0.2.5)
     signet (0.17.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    i18n-migrations (2.0.10)
+    i18n-migrations (2.1)
       activesupport
       colorize
       faraday

--- a/lib/i18n/migrations/migrator.rb
+++ b/lib/i18n/migrations/migrator.rb
@@ -1,5 +1,7 @@
 require 'fileutils'
 require 'yaml'
+require 'active_support/deprecation'
+require 'active_support/deprecator'
 require 'active_support/inflector'
 require 'active_support/core_ext/object'
 require 'colorize'

--- a/lib/i18n/migrations/version.rb
+++ b/lib/i18n/migrations/version.rb
@@ -1,5 +1,5 @@
 module I18n
   module Migrations
-    VERSION = "2.0.10"
+    VERSION = "2.1"
   end
 end


### PR DESCRIPTION
When using Active Support 7.1 and beyond, it is necessary to require Active Support's deprecation packages before requiring core Active Support libraries themselves.

This is needed for us to upgrade to Rails 7.1.

The tests in this gem's test suite do not appear to exercise the `I18n::Migrations::Migrator` class that I'm modifying here, which is why they weren't catching the issue with the missing deprecation package (and they won't catch any mistakes that I might have made in my changes).

This PR also takes the opportunity to bump `activesupport` to its latest version, and bumps the version of the gem to `2.1`.

I will need someone from @transparentclassroom/developers to do a gem release of the new version once this has been merged. (Or I can switch the main TC app to depend directly on this repo, whatever you prefer.)