### PR TITLE
Decouple Pull and Migrate actions [sh32801]

### DIFF
--- a/lib/i18n/migrations/backends/crowd_translate_backend.rb
+++ b/lib/i18n/migrations/backends/crowd_translate_backend.rb
@@ -12,7 +12,6 @@ module I18n
 
         def pull(locale)
           pull_from_crowd_translate(locale)
-          locale.migrate!
         end
 
         def push(locale, force: false)


### PR DESCRIPTION
https://app.shortcut.com/transparentclassroom/story/32801/

Pull should just be reading; and migrate should just be migrating.

Merging the two is convenient but causes surprising behavior when we take the pull action...