### PR TITLE
Validate requires Google Translate [sh37529]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 .env
 .i18n-migrations.yml
 /config/
+*.gem

--- a/bin/i18n-migrate
+++ b/bin/i18n-migrate
@@ -54,7 +54,7 @@ when 'push'
   nontranslating_migrator.push(ARGV[0] || 'all', force)
 
 when 'validate'
-  nontranslating_migrator.validate(ARGV[0] || 'all')
+  translating_migrator.validate(ARGV[0] || 'all')
 
 when 'new_locale'
   locale = ARGV.shift


### PR DESCRIPTION
When making `migrate` work without a Google Translate API Key, I presumed that `validate` would also work without a API Key.

To me, validation implies that the files are being checked that they all have the same keys.

However, in reality it means "we send it to Google and check for errors"